### PR TITLE
Fix invalid route parameter name

### DIFF
--- a/src/pages/compare/[serviceType].astro
+++ b/src/pages/compare/[serviceType].astro
@@ -19,7 +19,7 @@ export async function getStaticPaths() {
   ];
 
   return comparisonTypes.map((type) => ({
-    params: { 'service-type': type.slug },
+    params: { serviceType: type.slug },
     props: { comparisonType: type, services: services.filter(s => type.services.includes(s.id)) },
   }));
 }


### PR DESCRIPTION
Rename `[service-type].astro` to `[serviceType].astro` and update parameter references to comply with Astro's dynamic route parameter naming conventions.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b965cac-f812-4c7a-9ff3-af1a30000745">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b965cac-f812-4c7a-9ff3-af1a30000745">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

